### PR TITLE
Feat: zstd support

### DIFF
--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -108,6 +108,7 @@ jobs:
             libfl-dev \
             libbenchmark-dev \
             libgmock-dev \
+            libzstd-dev \
             libz-dev
       - name: Install cached non packaged dependencies
         if: steps.build-cache-restore-step.outputs.cache-hit != 'true' # Variable type is string, thus using quotes

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -283,6 +283,7 @@ jobs:
             google-benchmark \
             googletest \
             python@3.10 \
+            zstd \
             zlib
 
       - name: Build BlazingMQ

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -319,6 +319,7 @@ jobs:
             libfl-dev \
             libbenchmark-dev \
             libgmock-dev \
+            libzstd-dev \
             libz-dev \
             autoconf \
             libtool

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -60,6 +60,7 @@ jobs:
             libfl-dev \
             libbenchmark-dev \
             libgmock-dev \
+            libzstd-dev \
             libz-dev
 
       - name: Fetch & build non packaged dependencies

--- a/bin/build-ubuntu.sh
+++ b/bin/build-ubuntu.sh
@@ -6,7 +6,7 @@ echo -e "Before running this script, install the following prerequisites, if not
         "by executing the following commands:\n"                                               \
         "sudo apt update && sudo apt -y install ca-certificates\n"                             \
         "sudo apt install -y --no-install-recommends"                                          \
-        "autoconf automake build-essential gdb cmake ninja-build pkg-config bison libfl-dev libbenchmark-dev libgmock-dev libtool libz-dev"
+        "autoconf automake build-essential gdb cmake ninja-build pkg-config bison libfl-dev libbenchmark-dev libgmock-dev libtool libz-dev libzstd-dev"
 
 # :: Parse and validate arguments :::::::::::::::::::::::::::::::::::::::::::::
 print_usage_and_exit_with_error() {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
     libfl-dev \
     libbenchmark-dev \
     libgmock-dev \
+    libzstd-dev \
     libz-dev \
     libssl-dev \
     && apt clean \

--- a/etc/cmake/BmqPackageProvider.cmake
+++ b/etc/cmake/BmqPackageProvider.cmake
@@ -16,9 +16,11 @@ macro(setup_package_provider)
         # pkg-config style names BdeBuildSystem is trying to use.
         find_package(benchmark CONFIG REQUIRED)
         find_package(ZLIB REQUIRED)
+        find_package(ZSTD REQUIRED)
 
         add_library(benchmark ALIAS benchmark::benchmark)
         add_library(zlib ALIAS ZLIB::ZLIB)
+        add_library(zstd ALIAS ZSTD::ZSTD)
 
         find_package(GTest CONFIG REQUIRED)
         add_library(gmock ALIAS GTest::gmock)

--- a/etc/cmake/BmqPackageProvider.cmake
+++ b/etc/cmake/BmqPackageProvider.cmake
@@ -16,7 +16,7 @@ macro(setup_package_provider)
         # pkg-config style names BdeBuildSystem is trying to use.
         find_package(benchmark CONFIG REQUIRED)
         find_package(ZLIB REQUIRED)
-        find_package(ZSTD REQUIRED)
+        find_package(ZSTD REQUIRED libzstd)
 
         add_library(benchmark ALIAS benchmark::benchmark)
         add_library(zlib ALIAS ZLIB::ZLIB)

--- a/src/groups/bmq/bmqp/bmqp_compression.cpp
+++ b/src/groups/bmq/bmqp/bmqp_compression.cpp
@@ -309,33 +309,110 @@ int ZLib::writeOutput(bdlbb::Blob*              output,
 // struct Zstd
 // ===========
 
-const int ZSTD_COMPRESSION_FAST_SPECIAL =
-    1;  // special “fast” modes in some zstd versions
-const int ZSTD_COMPRESSION_DEFAULT = 0;   // which is usually 3
-const int ZSTD_COMPRESSION_FAST    = 1;   // fastest, lowest compression
-const int ZSTD_COMPRESSION_SLOW    = 19;  // slowest, highest compression
-const int ZSTD_COMPRESSION_MAX     = 22;
+namespace {
 
+// ZZstdStream mimic behavior of Zlib's z_stream for Zstd compression and
+// decompression operations.
 struct ZZstdStream {
+    // Zstd stream context.  This is a pointer to either a `ZSTD_CCtx` or
+    // `ZSTD_DCtx` depending on whether this stream is being used for
+    // compression or decompression.
     void* ctx;
 
+    // Number of bytes available at `next_in` buffer
     size_t avail_in;
+    // Number of bytes available at `next_out` buffer
     size_t avail_out;
 
+    // Next input byte to read
     char* next_in;
+    // Next output byte to write
     char* next_out;
+
+    // CLASS METHODS
+    // Update buffers positions after read/write operations
+    static void updateZstdStream(ZZstdStream*          stream,
+                                 const ZSTD_inBuffer&  in,
+                                 const ZSTD_outBuffer& out);
+
+    // Apply compression
+    static int deflateZstd(ZZstdStream* stream, ZSTD_EndDirective endOp);
+
+    // Apply decompression
+    static int inflateZstd(ZZstdStream* stream, ZSTD_EndDirective endOp);
+};
+
+inline void ZZstdStream::updateZstdStream(ZZstdStream*          stream,
+                                          const ZSTD_inBuffer&  in,
+                                          const ZSTD_outBuffer& out)
+{
+    size_t readFromIn = in.pos;
+    stream->avail_in -= readFromIn;
+    stream->next_in += readFromIn;
+
+    size_t addedToOut = out.pos;
+    stream->next_out += addedToOut;
+    stream->avail_out -= addedToOut;
+}
+
+int ZZstdStream::deflateZstd(ZZstdStream* stream, ZSTD_EndDirective endOp)
+{
+    ZSTD_inBuffer  in  = {stream->next_in, stream->avail_in, 0};
+    ZSTD_outBuffer out = {stream->next_out, stream->avail_out, 0};
+    size_t const   ret = ZSTD_compressStream2(
+        reinterpret_cast<ZSTD_CCtx*>(stream->ctx),
+        &out,
+        &in,
+        endOp);
+
+    if (ZSTD_isError(ret)) {
+        return -1;
+    }
+
+    updateZstdStream(stream, in, out);
+
+    return 0;
+};
+
+int ZZstdStream::inflateZstd(ZZstdStream* stream, ZSTD_EndDirective endOp)
+{
+    ZSTD_inBuffer  in  = {stream->next_in, stream->avail_in, 0};
+    ZSTD_outBuffer out = {stream->next_out, stream->avail_out, 0};
+    size_t const   ret = ZSTD_decompressStream(
+        reinterpret_cast<ZSTD_DCtx*>(stream->ctx),
+        &out,
+        &in);
+
+    if (ZSTD_isError(ret)) {
+        return -1;
+    }
+
+    updateZstdStream(stream, in, out);
+
+    return 0;
 };
 
 typedef int (*ZstdStreamMethod)(ZZstdStream*, ZSTD_EndDirective);
+};
 
 /// This struct provides the utility functions for enabling compression
 /// using Zstd algorithm.
 struct Zstd {
     // CONSTANTS
 
+    /// special “fast” modes in some zstd versions
+    static const int k_ZSTD_COMPRESSION_FAST_SPECIAL = 1;
+    /// Default compression which is usually 3
+    static const int k_ZSTD_COMPRESSION_DEFAULT = 0;
+    /// Fastest, lowest compression
+    static const int k_ZSTD_COMPRESSION_FAST = 1;
+    /// slowest, highest compression
+    static const int k_ZSTD_COMPRESSION_SLOW = 19;
+    ///  Maximum compression level
+    static const int k_ZSTD_COMPRESSION_MAX = 22;
+
     // CLASS METHODS
 
-    // static void*
     static void* zAllocate(void* opaque, size_t size);
 
     static void zFree(void* opaque, void* address);
@@ -602,7 +679,7 @@ int Compression::compress(bdlbb::Blob*                         output,
         return Compression_Impl::compressZstd(output,
                                               factory,
                                               inputBlob,
-                                              ZSTD_COMPRESSION_DEFAULT,
+                                              Zstd::k_ZSTD_COMPRESSION_DEFAULT,
                                               errorStream,
                                               allocator);  // RETURN
     }
@@ -691,56 +768,6 @@ int Compression_Impl::compressZlib(bdlbb::Blob*              output,
                              &::deflateEnd);
 }
 
-inline void updateZstdStream(ZZstdStream*          stream,
-                             const ZSTD_inBuffer&  in,
-                             const ZSTD_outBuffer& out)
-{
-    size_t readFromIn = in.pos;
-    stream->avail_in -= readFromIn;
-    stream->next_in += readFromIn;
-
-    size_t addedToOut = out.pos;
-    stream->next_out += addedToOut;
-    stream->avail_out -= addedToOut;
-}
-
-int deflateZstd(ZZstdStream* stream, ZSTD_EndDirective endOp)
-{
-    ZSTD_inBuffer  in  = {stream->next_in, stream->avail_in, 0};
-    ZSTD_outBuffer out = {stream->next_out, stream->avail_out, 0};
-    size_t const   ret = ZSTD_compressStream2(
-        reinterpret_cast<ZSTD_CCtx*>(stream->ctx),
-        &out,
-        &in,
-        endOp);
-
-    if (ZSTD_isError(ret)) {
-        return -1;
-    }
-
-    updateZstdStream(stream, in, out);
-
-    return 0;
-};
-
-int inflateZstd(ZZstdStream* stream, ZSTD_EndDirective endOp)
-{
-    ZSTD_inBuffer  in  = {stream->next_in, stream->avail_in, 0};
-    ZSTD_outBuffer out = {stream->next_out, stream->avail_out, 0};
-    size_t const   ret = ZSTD_decompressStream(
-        reinterpret_cast<ZSTD_DCtx*>(stream->ctx),
-        &out,
-        &in);
-
-    if (ZSTD_isError(ret)) {
-        return -1;
-    }
-
-    updateZstdStream(stream, in, out);
-
-    return 0;
-};
-
 int Compression_Impl::decompressZlib(bdlbb::Blob*              output,
                                      bdlbb::BlobBufferFactory* factory,
                                      const bdlbb::Blob&        input,
@@ -799,7 +826,7 @@ int Compression_Impl::compressZstd(bdlbb::Blob*              output,
                                          &stream,
                                          errorStream,
                                          input,
-                                         deflateZstd);
+                                         ZZstdStream::deflateZstd);
 
     ZSTD_freeCCtx(cctx);
 
@@ -830,7 +857,7 @@ int Compression_Impl::decompressZstd(bdlbb::Blob*              output,
                                          &stream,
                                          errorStream,
                                          input,
-                                         inflateZstd);
+                                         ZZstdStream::inflateZstd);
 
     ZSTD_freeDCtx(dctx);
 

--- a/src/groups/bmq/bmqp/bmqp_compression.cpp
+++ b/src/groups/bmq/bmqp/bmqp_compression.cpp
@@ -374,7 +374,8 @@ int ZZstdStream::deflateZstd(ZZstdStream* stream, ZSTD_EndDirective endOp)
     return 0;
 };
 
-int ZZstdStream::inflateZstd(ZZstdStream* stream, ZSTD_EndDirective endOp)
+int ZZstdStream::inflateZstd(ZZstdStream*                        stream,
+                             BSLA_MAYBE_UNUSED ZSTD_EndDirective endOp)
 {
     ZSTD_inBuffer  in  = {stream->next_in, stream->avail_in, 0};
     ZSTD_outBuffer out = {stream->next_out, stream->avail_out, 0};
@@ -619,6 +620,14 @@ int Compression::compress(bdlbb::Blob*                         output,
                                               Z_DEFAULT_COMPRESSION,
                                               errorStream,
                                               allocator);  // RETURN
+    case bmqt::CompressionAlgorithmType::e_ZSTD:
+        return Compression_Impl::compressZstd(output,
+                                              factory,
+                                              input,
+                                              Zstd::k_ZSTD_COMPRESSION_DEFAULT,
+                                              errorStream,
+                                              allocator);  // RETURN
+
     case bmqt::CompressionAlgorithmType::e_NONE:
         if (output->length() == 0) {
             *output = input;
@@ -819,7 +828,7 @@ int Compression_Impl::compressZstd(bdlbb::Blob*              output,
     }
     ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, level);
 
-    ZZstdStream stream = {cctx, 0, 0, nullptr, nullptr};
+    ZZstdStream stream = {cctx, 0, 0, NULL, NULL};
 
     const int result = Zstd::writeOutput(output,
                                          factory,
@@ -850,7 +859,7 @@ int Compression_Impl::decompressZstd(bdlbb::Blob*              output,
         return rc_STREAM_INIT_FAILURE;  // RETURN
     }
 
-    ZZstdStream stream = {dctx, 0, 0, nullptr, nullptr};
+    ZZstdStream stream = {dctx, 0, 0, NULL, NULL};
 
     const int result = Zstd::writeOutput(output,
                                          factory,

--- a/src/groups/bmq/bmqp/bmqp_compression.h
+++ b/src/groups/bmq/bmqp/bmqp_compression.h
@@ -141,6 +141,19 @@ struct Compression_Impl {
                               const bdlbb::Blob&        input,
                               bsl::ostream*             errorStream,
                               bslma::Allocator*         allocator);
+
+    static int compressZstd(bdlbb::Blob*              output,
+                            bdlbb::BlobBufferFactory* factory,
+                            const bdlbb::Blob&        input,
+                            int                       level,
+                            bsl::ostream*             errorStream,
+                            bslma::Allocator*         allocator);
+
+    static int decompressZstd(bdlbb::Blob*              output,
+                              bdlbb::BlobBufferFactory* factory,
+                              const bdlbb::Blob&        input,
+                              bsl::ostream*             errorStream,
+                              bslma::Allocator*         allocator);
 };
 
 }  // close package namespace

--- a/src/groups/bmq/bmqp/bmqp_compression.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_compression.t.cpp
@@ -285,9 +285,11 @@ static void eAnyCompressDecompressHelper(
     int   bufferSize     = bmqu::BlobUtil::bufferSize(compressed, 0);
     char* receivedBuffer = compressed.buffer(0).data();
 
-    BMQTST_ASSERT_EQ(
-        bsl::memcmp(expectedCompressed, receivedBuffer, bufferSize),
-        0);
+    if (expectedCompressed != nullptr) {
+        BMQTST_ASSERT_EQ(
+            bsl::memcmp(expectedCompressed, receivedBuffer, bufferSize),
+            0);
+    }
 
     startTime          = bsls::TimeUtil::getTimer();
     rc                 = bmqp::Compression::decompress(&decompressed,
@@ -802,13 +804,10 @@ static void test4_compression_decompression_zstd()
             int         d_line;
             const char* d_data;
             const char* d_expected;
-        } k_DATA[] = {{L_, "Hello World", "Hello World"},
-                      {L_, "HelloHello", "HelloHello"},
-                      {L_, "abcdefghij", "abcdefghij"},
-                      {L_,
-                       "Hello Hello Hello Hello Hello",
-                       "Hello Hello Hello "
-                       "Hello Hello"}};
+        } k_DATA[] = {{L_, "Hello World", nullptr},
+                      {L_, "HelloHello", nullptr},
+                      {L_, "abcdefghij", nullptr},
+                      {L_, "Hello Hello Hello Hello Hello", nullptr}};
 
         const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);
 
@@ -1125,7 +1124,7 @@ static void testN4_performanceCompressionRatioZstd()
     populateData(&data);
 
     // Measure calculation time and report per level
-    for (int level = 0; level < 10; level++) {
+    for (int level = 1; level <= 19; level++) {
         bsl::cout << "---------------------\n"
                   << " LEVEL = " << level << '\n'
                   << "---------------------\n";

--- a/src/groups/bmq/bmqp/bmqp_compression.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_compression.t.cpp
@@ -349,7 +349,6 @@ eZlibCompressDecompressHelper(bsls::Types::Int64* compressionTime,
     BMQTST_ASSERT_EQ(bdlbb::BlobUtil::compare(decompressed, input), 0);
 }
 
-
 template <typename D>
 static void
 eZstdCompressDecompressHelper(bsls::Types::Int64* compressionTime,
@@ -1086,7 +1085,6 @@ static void testN1_performanceCompressionDecompressionZlib()
     printTable(bsl::cout, headerCols, tableRecords);
 }
 
-
 BSLA_MAYBE_UNUSED
 static void testN1_performanceCompressionDecompressionZstd()
 // ------------------------------------------------------------------------
@@ -1587,7 +1585,8 @@ static void testN1_performanceCompressionDecompressionZstd_GoogleBenchmark(
     // </time>
 }
 
-static void testN2_calculateThroughputZlib_GoogleBenchmark(benchmark::State& state)
+static void
+testN2_calculateThroughputZlib_GoogleBenchmark(benchmark::State& state)
 // ------------------------------------------------------------------------
 // BENCHMARK: PERFORM COMPRESSION DECOMPRESSION
 //
@@ -1612,7 +1611,7 @@ static void testN2_calculateThroughputZlib_GoogleBenchmark(benchmark::State& sta
     bsl::string buffer_data("", bmqtst::TestHelperUtil::allocator());
     generateRandomString(&buffer_data, length);
     // <time>
-    // for (unsigned int l = 0; l < state.range(0); ++l) 
+    // for (unsigned int l = 0; l < state.range(0); ++l)
     {
         bsls::Types::Int64 compressionTotal = 0, decompressionTotal = 0;
         for (auto _ : state) {
@@ -1624,8 +1623,8 @@ static void testN2_calculateThroughputZlib_GoogleBenchmark(benchmark::State& sta
     // </time>
 }
 
-
-static void testN2_calculateThroughputZstd_GoogleBenchmark(benchmark::State& state)
+static void
+testN2_calculateThroughputZstd_GoogleBenchmark(benchmark::State& state)
 // ------------------------------------------------------------------------
 // BENCHMARK: PERFORM COMPRESSION DECOMPRESSION
 //
@@ -1650,7 +1649,7 @@ static void testN2_calculateThroughputZstd_GoogleBenchmark(benchmark::State& sta
     bsl::string buffer_data("", bmqtst::TestHelperUtil::allocator());
     generateRandomString(&buffer_data, length);
     // <time>
-    // for (unsigned int l = 0; l < state.range(0); ++l) 
+    // for (unsigned int l = 0; l < state.range(0); ++l)
     {
         bsls::Types::Int64 compressionTotal = 0, decompressionTotal = 0;
         for (auto _ : state) {
@@ -1674,9 +1673,9 @@ int main(int argc, char* argv[])
     case 0:
     case 1: test1_breathingTest(); break;
     case 2: test2_compression_cluster_message(); break;
-    case 3: 
-        test3_compression_decompression_none(); 
-        test3_compression_decompression_zstd(); 
+    case 3:
+        test3_compression_decompression_none();
+        test3_compression_decompression_zstd();
         break;
     case -1:
         BMQTST_BENCHMARK_WITH_ARGS(
@@ -1703,11 +1702,11 @@ int main(int argc, char* argv[])
                                        ->Unit(benchmark::kMillisecond));
 
         break;
-    case -3: 
-        testN3_performanceCompressionRatio(); 
-        testN3_performanceCompressionRatioZstd(); 
+    case -3:
+        testN3_performanceCompressionRatio();
+        testN3_performanceCompressionRatioZstd();
         break;
-    
+
     default: {
         cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
         bmqtst::TestHelperUtil::testStatus() = -1;

--- a/src/groups/bmq/bmqp/bmqp_compression.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_compression.t.cpp
@@ -249,7 +249,7 @@ static void populateData(bsl::vector<bsl::string>* data)
 }
 
 template <typename D>
-static void eAnyCompressDecompressHelper(
+static void eCompressDecompressHelper(
     bsls::Types::Int64*                         compressionTime,
     bsls::Types::Int64*                         decompressionTime,
     const D&                                    data,
@@ -570,12 +570,11 @@ static void test1_breathingTest()
             bsls::Types::Int64 decompressionTime = 0;
             bsl::string        inputString(test.d_data,
                                     bmqtst::TestHelperUtil::allocator());
-            eAnyCompressDecompressHelper(
-                &compressionTime,
-                &decompressionTime,
-                inputString,
-                test.d_expected,
-                bmqt::CompressionAlgorithmType::e_ZLIB);
+            eCompressDecompressHelper(&compressionTime,
+                                      &decompressionTime,
+                                      inputString,
+                                      test.d_expected,
+                                      bmqt::CompressionAlgorithmType::e_ZLIB);
         }
     }
 
@@ -586,11 +585,11 @@ static void test1_breathingTest()
         const bsl::string  data("", bmqtst::TestHelperUtil::allocator());
         bsls::Types::Int64 compressionTime   = 0;
         bsls::Types::Int64 decompressionTime = 0;
-        eAnyCompressDecompressHelper(&compressionTime,
-                                     &decompressionTime,
-                                     data,
-                                     "\x78\x9c\x3\x0\x0\x0\x0\x1",
-                                     bmqt::CompressionAlgorithmType::e_ZLIB);
+        eCompressDecompressHelper(&compressionTime,
+                                  &decompressionTime,
+                                  data,
+                                  "\x78\x9c\x3\x0\x0\x0\x0\x1",
+                                  bmqt::CompressionAlgorithmType::e_ZLIB);
     }
 
     {
@@ -829,12 +828,11 @@ static void test3_compression_decompression_none()
             bsls::Types::Int64 decompressionTime = 0;
             bsl::string        inputString(test.d_data,
                                     bmqtst::TestHelperUtil::allocator());
-            eAnyCompressDecompressHelper(
-                &compressionTime,
-                &decompressionTime,
-                inputString,
-                test.d_expected,
-                bmqt::CompressionAlgorithmType::e_NONE);
+            eCompressDecompressHelper(&compressionTime,
+                                      &decompressionTime,
+                                      inputString,
+                                      test.d_expected,
+                                      bmqt::CompressionAlgorithmType::e_NONE);
         }
     }
 }
@@ -871,12 +869,11 @@ static void test3_compression_decompression_zstd()
             bsls::Types::Int64 decompressionTime = 0;
             bsl::string        inputString(test.d_data,
                                     bmqtst::TestHelperUtil::allocator());
-            eAnyCompressDecompressHelper(
-                &compressionTime,
-                &decompressionTime,
-                inputString,
-                test.d_expected,
-                bmqt::CompressionAlgorithmType::e_ZSTD);
+            eCompressDecompressHelper(&compressionTime,
+                                      &decompressionTime,
+                                      inputString,
+                                      test.d_expected,
+                                      bmqt::CompressionAlgorithmType::e_ZSTD);
 
             //=====================================================================
             //                            Report
@@ -956,13 +953,12 @@ static void test3_compression_decompression_zstd()
             bsls::Types::Int64 decompressionTime = 0;
             bsl::string        inputString(test.d_data,
                                     bmqtst::TestHelperUtil::allocator());
-            eAnyCompressDecompressHelper(
-                &compressionTime,
-                &decompressionTime,
-                inputString,
-                test.d_expected,
-                bmqt::CompressionAlgorithmType::e_ZSTD,
-                test.d_compressedBuffersNum);
+            eCompressDecompressHelper(&compressionTime,
+                                      &decompressionTime,
+                                      inputString,
+                                      test.d_expected,
+                                      bmqt::CompressionAlgorithmType::e_ZSTD,
+                                      test.d_compressedBuffersNum);
 
             //=====================================================================
             //                            Report
@@ -1348,7 +1344,7 @@ static void testN2_calculateThroughputZstd()
          << endl;
 }
 
-static void testN3_performanceCompressionRatio()
+static void testN3_performanceCompressionRatioZlib()
 // ------------------------------------------------------------------------
 // BENCHMARK: COMPRESSION RATIO
 //
@@ -1370,7 +1366,7 @@ static void testN3_performanceCompressionRatio()
     // The default allocator check fails in this test case because the
     // printTable method utilizes the global allocator.
 
-    bmqtst::TestHelper::printTestName("BENCHMARK: COMPRESSION RATIO");
+    bmqtst::TestHelper::printTestName("BENCHMARK: ZLIB COMPRESSION RATIO");
 
     bsl::vector<bsl::string> data(bmqtst::TestHelperUtil::allocator());
     populateData(&data);
@@ -1453,7 +1449,7 @@ static void testN3_performanceCompressionRatioZstd()
     // The default allocator check fails in this test case because the
     // printTable method utilizes the global allocator.
 
-    bmqtst::TestHelper::printTestName("BENCHMARK: COMPRESSION RATIO");
+    bmqtst::TestHelper::printTestName("BENCHMARK: ZSTD COMPRESSION RATIO");
 
     bsl::vector<bsl::string> data(bmqtst::TestHelperUtil::allocator());
     populateData(&data);
@@ -1540,7 +1536,7 @@ static void testN1_performanceCompressionDecompressionZlib_GoogleBenchmark(
     // The default allocator check fails in this test case because the
     // printTable method utilizes the global allocator.
 
-    bmqtst::TestHelper::printTestName("GOOGLE BENCHMARK PERFORMANCE: "
+    bmqtst::TestHelper::printTestName("GOOGLE BENCHMARK ZLIB PERFORMANCE: "
                                       "COMPRESS/DECOMPRESS ON BUFFER");
     const int   length = state.range(0);
     bsl::string str("", bmqtst::TestHelperUtil::allocator());
@@ -1566,7 +1562,7 @@ static void testN1_performanceCompressionDecompressionZstd_GoogleBenchmark(
     // The default allocator check fails in this test case because the
     // printTable method utilizes the global allocator.
 
-    bmqtst::TestHelper::printTestName("GOOGLE BENCHMARK PERFORMANCE: "
+    bmqtst::TestHelper::printTestName("GOOGLE BENCHMARK ZSTD PERFORMANCE: "
                                       "COMPRESS/DECOMPRESS ON BUFFER");
     const int   length = state.range(0);
     bsl::string str("", bmqtst::TestHelperUtil::allocator());
@@ -1604,15 +1600,14 @@ testN2_calculateThroughputZlib_GoogleBenchmark(benchmark::State& state)
 //   implementation in a single thread environment.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelper::printTestName("GOOGLE BENCHMARK THROUGHPUT: "
+    bmqtst::TestHelper::printTestName("GOOGLE BENCHMARK ZLIB THROUGHPUT: "
                                       "COMPRESS/DECOMPRESS ON BUFFER");
     size_t length = 1024;  // 1 Ki
 
     bsl::string buffer_data("", bmqtst::TestHelperUtil::allocator());
     generateRandomString(&buffer_data, length);
     // <time>
-    // for (unsigned int l = 0; l < state.range(0); ++l)
-    {
+    for (unsigned int l = 0; l < state.range(0); ++l) {
         bsls::Types::Int64 compressionTotal = 0, decompressionTotal = 0;
         for (auto _ : state) {
             eZlibCompressDecompressHelper(&compressionTotal,
@@ -1642,15 +1637,14 @@ testN2_calculateThroughputZstd_GoogleBenchmark(benchmark::State& state)
 //   implementation in a single thread environment.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelper::printTestName("GOOGLE BENCHMARK THROUGHPUT: "
+    bmqtst::TestHelper::printTestName("GOOGLE BENCHMARK ZSTD THROUGHPUT: "
                                       "COMPRESS/DECOMPRESS ON BUFFER");
     size_t length = 1024;  // 1 Ki
 
     bsl::string buffer_data("", bmqtst::TestHelperUtil::allocator());
     generateRandomString(&buffer_data, length);
     // <time>
-    // for (unsigned int l = 0; l < state.range(0); ++l)
-    {
+    for (unsigned int l = 0; l < state.range(0); ++l) {
         bsls::Types::Int64 compressionTotal = 0, decompressionTotal = 0;
         for (auto _ : state) {
             eZstdCompressDecompressHelper(&compressionTotal,
@@ -1703,7 +1697,7 @@ int main(int argc, char* argv[])
 
         break;
     case -3:
-        testN3_performanceCompressionRatio();
+        testN3_performanceCompressionRatioZlib();
         testN3_performanceCompressionRatioZstd();
         break;
 

--- a/src/groups/bmq/bmqp/bmqp_compression.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_compression.t.cpp
@@ -284,7 +284,7 @@ static void eCompressDecompressHelper(
     // get compressed data and compare with expected_compressed
     BSLS_ASSERT_SAFE(compressed.numDataBuffers() == compressedBuffersNum);
 
-    if (compressedBuffersNum == 1 && expectedCompressed != nullptr) {
+    if (compressedBuffersNum == 1 && expectedCompressed != NULL) {
         int   bufferSize     = bmqu::BlobUtil::bufferSize(compressed, 0);
         char* receivedBuffer = compressed.buffer(0).data();
 
@@ -851,10 +851,10 @@ static void test3_compression_decompression_zstd()
             int         d_line;
             const char* d_data;
             const char* d_expected;
-        } k_DATA[] = {{L_, "Hello World", nullptr},
-                      {L_, "HelloHello", nullptr},
-                      {L_, "abcdefghij", nullptr},
-                      {L_, "Hello Hello Hello Hello Hello", nullptr}};
+        } k_DATA[] = {{L_, "Hello World", NULL},
+                      {L_, "HelloHello", NULL},
+                      {L_, "abcdefghij", NULL},
+                      {L_, "Hello Hello Hello Hello Hello", NULL}};
 
         const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);
 
@@ -902,7 +902,6 @@ static void test3_compression_decompression_zstd()
             const char* d_data;
             const char* d_expected;
             int         d_compressedBuffersNum;
-            ;
         } k_DATA[] = {
             {L_,
              "yhemjqtitnqrwrupsapufiulldbmdyeggntrvaplnqlxchojckigrkoizdbzkqpw"
@@ -937,7 +936,7 @@ static void test3_compression_decompression_zstd()
              "blwwvqfljopsieqakcjbpilsjxfvhczzozxydwctdszapwvlszcmpqkkbntxvaca"
              "hatxsymuemoxplwfyorvfselrifgrijlcyuugsdexrsanxlcezwdhqstcbyhtojo"
              "nrhiouftlxjcqmjtlfogwggkejsszpxyqxod",
-             nullptr,
+             NULL,
              2}};
 
         const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);

--- a/src/groups/bmq/bmqt/bmqt_compressionalgorithmtype.cpp
+++ b/src/groups/bmq/bmqt/bmqt_compressionalgorithmtype.cpp
@@ -54,6 +54,7 @@ CompressionAlgorithmType::toAscii(CompressionAlgorithmType::Enum value)
         BMQT_CASE(UNKNOWN)
         BMQT_CASE(NONE)
         BMQT_CASE(ZLIB)
+        BMQT_CASE(ZSTD)
     default: return "(* UNKNOWN *)";
     }
 
@@ -73,6 +74,7 @@ bool CompressionAlgorithmType::fromAscii(CompressionAlgorithmType::Enum* out,
 
     BMQT_CHECKVALUE(NONE);
     BMQT_CHECKVALUE(ZLIB);
+    BMQT_CHECKVALUE(ZSTD);
 
     // Invalid string
     return false;
@@ -88,7 +90,8 @@ bool CompressionAlgorithmType::isValid(const bsl::string* str,
         return true;  // RETURN
     }
 
-    stream << "Error: compressionAlgorithmType must be one of [NONE, ZLIB]\n";
+    stream << "Error: compressionAlgorithmType must be one of [NONE, ZLIB, "
+              "ZSTD]\n";
     return false;
 }
 

--- a/src/groups/bmq/bmqt/bmqt_compressionalgorithmtype.h
+++ b/src/groups/bmq/bmqt/bmqt_compressionalgorithmtype.h
@@ -43,7 +43,7 @@ namespace bmqt {
 /// This struct defines various types of compression algorithms.
 struct CompressionAlgorithmType {
     // TYPES
-    enum Enum { e_UNKNOWN = -1, e_NONE = 0, e_ZLIB = 1 };
+    enum Enum { e_UNKNOWN = -1, e_NONE = 0, e_ZLIB = 1, e_ZSTD = 2 };
 
     // CONSTANTS
 

--- a/src/groups/bmq/bmqt/bmqt_compressionalgorithmtype.h
+++ b/src/groups/bmq/bmqt/bmqt_compressionalgorithmtype.h
@@ -26,7 +26,7 @@
 ///
 ///   - *NONE*: No compression algorithm was specified
 ///   - *ZLIB*: The compression algorithm is ZLIB
-
+///   - *ZSTD*: The compression algorithm is ZSTD
 // BMQ
 
 // BDE
@@ -55,7 +55,7 @@ struct CompressionAlgorithmType {
     /// NOTE: This value must always be equal to the highest type in the
     /// enum because it is being used as an upper bound to verify that a
     /// header's `CompressionAlgorithmType` field is a supported type.
-    static const int k_HIGHEST_SUPPORTED_TYPE = e_ZLIB;
+    static const int k_HIGHEST_SUPPORTED_TYPE = e_ZSTD;
 
     // CLASS METHODS
 

--- a/src/groups/bmq/bmqt/bmqt_compressionalgorithmtype.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_compressionalgorithmtype.t.cpp
@@ -108,12 +108,13 @@ static void test1_enumPrint()
 
         BSLMF_ASSERT(
             bmqt::CompressionAlgorithmType::k_HIGHEST_SUPPORTED_TYPE ==
-            bmqt::CompressionAlgorithmType::e_ZLIB);
+            bmqt::CompressionAlgorithmType::e_ZSTD);
 
         PrintTestData k_DATA[] = {
             {L_, bmqt::CompressionAlgorithmType::e_UNKNOWN, "UNKNOWN"},
             {L_, bmqt::CompressionAlgorithmType::e_NONE, "NONE"},
             {L_, bmqt::CompressionAlgorithmType::e_ZLIB, "ZLIB"},
+            {L_, bmqt::CompressionAlgorithmType::e_ZSTD, "ZSTD"},
             {L_,
              bmqt::CompressionAlgorithmType::k_HIGHEST_SUPPORTED_TYPE + 1,
              "(* UNKNOWN *)"}};

--- a/src/groups/bmq/group/bmq.dep
+++ b/src/groups/bmq/group/bmq.dep
@@ -10,3 +10,4 @@ bdl
 # Level 1
 bsl
 zlib
+libzstd

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,6 +8,7 @@
         "ntf-core",
         "benchmark",
         "gtest",
+        "zstd",
         "zlib"
     ]
 }


### PR DESCRIPTION
[*Issue number of the reported bug or feature request: #<number>*](https://github.com/bloomberg/blazingmq/issues/798)

**Describe your changes**
Implemented support for compression via Zstd 


**Perf Benchmarking**
<img width="599" height="371" alt="image" src="https://github.com/user-attachments/assets/50386984-6dcd-4f42-ab42-e289b97fe78d" />

Speedup Log Scale:
<img width="621" height="383" alt="image" src="https://github.com/user-attachments/assets/993969fd-680b-4e4a-a2c5-d682f66ace7d" />


```
$ ./tests/bmqp_compression.t -1
TEST /home/dpetukhov/projects/bbpetukhov/blazingmq/src/groups/bmq/bmqp/bmqp_compression.t.cpp CASE -1
2025-09-25T18:38:21+03:00
Running ./tests/bmqp_compression.t
Run on (8 X 2803.2 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 1280 KiB (x4)
  L3 Unified 12288 KiB (x1)
Load Average: 0.84, 0.96, 0.58
***WARNING*** Library was built as DEBUG. Timings may be affected.
--------------------------------------------------------------------------------------------------------------------
Benchmark                                                                          Time             CPU   Iterations
--------------------------------------------------------------------------------------------------------------------
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/2               0.093 ms        0.093 ms         7907
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/4               0.153 ms        0.155 ms         6837
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/8               0.094 ms        0.096 ms         7384
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/16              0.105 ms        0.107 ms         7090
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/32              0.109 ms        0.112 ms         5695
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/64              0.098 ms        0.101 ms         9403
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/128             0.091 ms        0.094 ms         7326
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/256             0.088 ms        0.091 ms         8263
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/512             0.104 ms        0.107 ms         5086
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/1024            0.101 ms        0.105 ms         7626
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/2048            0.153 ms        0.158 ms         5804
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/4096            0.201 ms        0.207 ms         3256
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/8192            0.329 ms        0.340 ms         1954
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/16384           0.755 ms        0.794 ms          975
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/32768            1.67 ms         1.76 ms          361
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/65536            3.81 ms         4.01 ms          143
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/131072           7.69 ms         8.09 ms           95
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/262144           18.7 ms         19.5 ms           49
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/524288           50.4 ms         51.5 ms           10
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/1048576          79.4 ms         81.1 ms            8
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/2097152           153 ms          156 ms            7
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/4194304           305 ms          311 ms            2
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/8388608           537 ms          549 ms            1
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/16777216         1194 ms         1220 ms            1
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/33554432         2222 ms         2269 ms            1
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/67108864         5755 ms         5794 ms            1
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/134217728       10078 ms        10475 ms            1
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/268435456       20994 ms        21482 ms            1
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/536870912       40369 ms        41311 ms            1
testN1_performanceCompressionDecompressionZlib_GoogleBenchmark/1073741824      83818 ms        84545 ms            1
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/2               0.085 ms        0.086 ms         8412
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/4               0.077 ms        0.078 ms         9967
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/8               0.091 ms        0.092 ms         9691
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/16              0.091 ms        0.091 ms         5791
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/32              0.082 ms        0.083 ms         8729
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/64              0.116 ms        0.119 ms         5455
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/128             0.120 ms        0.124 ms         5176
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/256             0.100 ms        0.104 ms         8403
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/512             0.116 ms        0.120 ms         5298
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/1024            0.095 ms        0.099 ms         6197
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/2048            0.119 ms        0.123 ms         5064
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/4096            0.115 ms        0.115 ms         4671
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/8192            0.109 ms        0.109 ms         7111
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/16384           0.113 ms        0.113 ms         6000
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/32768           0.138 ms        0.139 ms         5927
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/65536           0.165 ms        0.166 ms         3516
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/131072          0.203 ms        0.206 ms         3542
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/262144          0.367 ms        0.371 ms         1520
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/524288          0.916 ms        0.927 ms          755
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/1048576          1.49 ms         1.50 ms          623
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/2097152          3.36 ms         3.40 ms          221
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/4194304          6.50 ms         6.61 ms          100
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/8388608          18.8 ms         19.1 ms           51
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/16777216         37.3 ms         37.6 ms           21
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/33554432          101 ms          103 ms            5
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/67108864          190 ms          195 ms            3
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/134217728         540 ms          547 ms            1
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/268435456        1346 ms         1363 ms            1
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/536870912        3055 ms         3098 ms            1
testN1_performanceCompressionDecompressionZstd_GoogleBenchmark/1073741824       7999 ms         8114 ms            1
```

**Throughput benchmarking**
```
$ ./tests/bmqp_compression.t -2
TEST /home/dpetukhov/projects/bbpetukhov/blazingmq/src/groups/bmq/bmqp/bmqp_compression.t.cpp CASE -2
2025-09-25T18:36:40+03:00
Running ./tests/bmqp_compression.t
Run on (8 X 2803.2 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 1280 KiB (x4)
  L3 Unified 12288 KiB (x1)
Load Average: 3.57, 1.25, 0.62
***WARNING*** Library was built as DEBUG. Timings may be affected.
-------------------------------------------------------------------------------------------------
Benchmark                                                       Time             CPU   Iterations
-------------------------------------------------------------------------------------------------
testN2_calculateThroughputZlib_GoogleBenchmark/100          0.115 ms        0.116 ms         6620
testN2_calculateThroughputZlib_GoogleBenchmark/1000         0.109 ms        0.111 ms         5828
testN2_calculateThroughputZlib_GoogleBenchmark/10000        0.125 ms        0.127 ms         5220
testN2_calculateThroughputZlib_GoogleBenchmark/100000       0.134 ms        0.136 ms         6663
testN2_calculateThroughputZlib_GoogleBenchmark/1000000      0.131 ms        0.133 ms         6580
testN2_calculateThroughputZstd_GoogleBenchmark/100          0.082 ms        0.083 ms         9332
testN2_calculateThroughputZstd_GoogleBenchmark/1000         0.119 ms        0.125 ms         5026
testN2_calculateThroughputZstd_GoogleBenchmark/10000        0.101 ms        0.108 ms         5134
testN2_calculateThroughputZstd_GoogleBenchmark/100000       0.085 ms        0.091 ms         8104
testN2_calculateThroughputZstd_GoogleBenchmark/1000000      0.080 ms        0.086 ms         8664
```